### PR TITLE
Fix missing solana dependency and logging utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ uvicorn==0.24.0
 nest_asyncio==1.5.8
 
 # Solana blockchain
-solana==0.30.2
-solders==0.18.1
+solana==0.36.7
+solders==0.26.0
 base58==2.1.1
 
 # Async HTTP

--- a/src/bot/feeds.py
+++ b/src/bot/feeds.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, Optional
 import logging
+import os
 
 logger = logging.getLogger("bot.feeds")
 

--- a/src/bot/utils.py
+++ b/src/bot/utils.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure basic logging for the bot."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )


### PR DESCRIPTION
## Summary
- update Solana dependencies to use recent versions that work with httpx>=0.24
- add simple setup_logging helper
- import `os` in `feeds`

## Testing
- `pip install -r requirements.txt`
- `python test_bot.py` *(fails: Cannot connect to host api.dexscreener.com)*

------
https://chatgpt.com/codex/tasks/task_e_686e4e4f3ca88320ba6f955fe945e9ef