### PR TITLE
Fix startup error by updating httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ base58==2.1.1
 
 # Async HTTP
 aiohttp==3.9.1
-httpx==0.25.2
+httpx==0.26.0
 requests==2.31.0
 
 # Utils


### PR DESCRIPTION
## Summary
- bump httpx to 0.26.0 to restore proxy compatibility

## Testing
- `python test_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_686e508624188320b942b1108af955ca