### PR TITLE
Add Moralis API test module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ Bot automat pentru trading de meme-coins pe Solana cu strategie de sniping pentr
 
 În notebook-ul Colab, urmează pașii din interfața interactivă.
 
+### 🔬 Testare rapidă Moralis API
+
+Pentru a verifica dacă cheia Moralis funcționează, rulează scriptul
+`test_moralis_api.py` sau deschide notebook-ul dedicat:
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/YOUR_USERNAME/solana-sniper-bot/blob/main/notebooks/moralis_api_test.ipynb)
+
+Setează variabila `MORALIS_KEY` în mediul Colab pentru a putea accesa
+endpoint-urile Moralis.
+
 ## ⚠️ Disclaimer
 
 **AVERTISMENT**: Trading-ul de crypto implică **RISC EXTREM DE MARE**.

--- a/notebooks/moralis_api_test.ipynb
+++ b/notebooks/moralis_api_test.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Moralis API Quick Test\n",
+    "Demonstrates basic calls using the `MoralisAPI` class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q httpx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "import sys\n",
+    "sys.path.append(str(Path('..').resolve()))\n",
+    "from src.api.moralis import MoralisAPI\n",
+    "\n",
+    "api_key = os.getenv('MORALIS_KEY')\n",
+    "assert api_key, 'Set MORALIS_KEY in environment'\n",
+    "client = MoralisAPI(api_key)\n",
+    "data = await client.get_token_price('mainnet', 'So11111111111111111111111111111111111111112')\n",
+    "data"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,1 +1,5 @@
-"""API module for bot control."""
+"""API wrappers used by the project."""
+
+from .moralis import MoralisAPI
+
+__all__ = ["MoralisAPI"]

--- a/src/api/moralis.py
+++ b/src/api/moralis.py
@@ -1,0 +1,48 @@
+import os
+import httpx
+from typing import Any, Dict, Optional
+
+class MoralisAPI:
+    """Simple async wrapper for Moralis Solana endpoints."""
+
+    BASE_URL = "https://solana-gateway.moralis.io"
+
+    def __init__(self, api_key: Optional[str] = None) -> None:
+        self.api_key = api_key or os.getenv("MORALIS_KEY")
+        if not self.api_key:
+            raise ValueError("Moralis API key not provided")
+        self.headers = {"X-API-Key": self.api_key}
+
+    async def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        url = f"{self.BASE_URL}{path}"
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, params=params, headers=self.headers)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def get_token_metadata(self, network: str, address: str) -> Dict[str, Any]:
+        """Retrieve metadata for a SPL token."""
+        return await self._get(f"/token/{network}/{address}/metadata")
+
+    async def get_token_price(self, network: str, address: str) -> Dict[str, Any]:
+        """Retrieve token price information."""
+        return await self._get(f"/token/{network}/{address}/price")
+
+    async def get_wallet_tokens(self, network: str, address: str) -> Dict[str, Any]:
+        """Retrieve SPL token balances for a wallet."""
+        return await self._get(f"/account/{network}/{address}/tokens")
+
+
+async def main() -> None:
+    """Basic usage example printing a few API calls."""
+    api = MoralisAPI()
+    # Wrapped SOL address
+    sol_address = "So11111111111111111111111111111111111111112"
+    metadata = await api.get_token_metadata("mainnet", sol_address)
+    print("Metadata:", metadata)
+    price = await api.get_token_price("mainnet", sol_address)
+    print("Price:", price)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/test_moralis_api.py
+++ b/test_moralis_api.py
@@ -1,0 +1,23 @@
+"""Simple checks for MoralisAPI endpoints."""
+import asyncio
+import os
+
+from src.api.moralis import MoralisAPI
+
+async def run() -> None:
+    api_key = os.getenv("MORALIS_KEY")
+    if not api_key:
+        print("MORALIS_KEY env var missing")
+        return
+
+    api = MoralisAPI(api_key)
+    token = "So11111111111111111111111111111111111111112"  # wrapped SOL
+
+    meta = await api.get_token_metadata("mainnet", token)
+    print("Token Metadata:", meta)
+
+    price = await api.get_token_price("mainnet", token)
+    print("Token Price:", price)
+
+if __name__ == "__main__":
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- create a `MoralisAPI` wrapper with async helpers for Solana
- add `test_moralis_api.py` script for quick checks
- provide Colab notebook example
- document Moralis API testing in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e5c834fec8320827674d78cc64675