### PR TITLE
Improve API integration and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Bot automat pentru trading de meme-coins pe Solana cu strategie de sniping pentr
 - **🤖 Trading Automat**: Entry/exit bazat pe score și parametri configurabili
 - **💰 Management Poziții**: Take profit, stop loss, position sizing
 - **📈 Dashboard Live**: Interfață Gradio pentru monitorizare în timp real
+- **🚀 Detecție 3x/5x/10x**: Heuristici simple pentru identificarea pump-urilor
 - **🔒 Wallet Secure**: Suport pentru Phantom și alte wallet-uri Solana
 
 ## 🚀 Quick Start în Google Colab
@@ -48,6 +49,34 @@ Pentru a verifica dacă cheia Moralis funcționează, rulează scriptul
 
 Setează variabila `MORALIS_KEY` în mediul Colab pentru a putea accesa
 endpoint-urile Moralis.
+
+### 🛠 Integrare API-uri
+
+Proiectul folosește trei surse principale de date:
+
+1. **DEX Screener** – căutare perechi noi pe Solana
+   ```python
+   from src.api.dexscreener import DexScreenerAPI
+   api = DexScreenerAPI()
+   pairs = await api.search_tokens("solana")
+   ```
+
+2. **Moralis** – prețuri și metadata token
+   ```python
+   from src.api.moralis import MoralisAPI
+   api = MoralisAPI("YOUR_MORALIS_KEY")
+   price = await api.get_token_price("mainnet", token_address)
+   ```
+
+3. **Helius** – detalii suplimentare despre holderi
+   ```python
+   from src.api.helius import HeliusAPI
+   api = HeliusAPI("YOUR_HELIUS_KEY")
+   holders = await api.get_token_holders(token_address)
+   ```
+
+Aceste module pot fi testate rapid în Google Colab folosind notebook-ul
+`notebooks/sniper_colab.ipynb`.
 
 ## ⚠️ Disclaimer
 

--- a/gradio_ui.py
+++ b/gradio_ui.py
@@ -34,7 +34,8 @@ def launch_dashboard(share: bool = False) -> None:
             lines.append(f"{i}. {token.symbol} ({token.address[:8]}...)")
             lines.append(f"   Price: ${token.price:.6f} | Change 5m: {token.price_change_5m:+.2f}%")
             lines.append(f"   Volume 5m: ${token.volume_5m:,.0f} | Liquidity: ${token.liquidity:,.0f}")
-            lines.append(f"   Score: {token.score:.1f}/100\n")
+            opp = f" | Opportunity: {token.opportunity}" if token.opportunity else ""
+            lines.append(f"   Score: {token.score:.1f}/100{opp}\n")
             
         return "\n".join(lines)
     

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,5 +1,9 @@
 """API wrappers used by the project."""
 
-from .moralis import MoralisAPI
+"""API wrappers used by the project."""
 
-__all__ = ["MoralisAPI"]
+from .moralis import MoralisAPI
+from .helius import HeliusAPI
+from .dexscreener import DexScreenerAPI
+
+__all__ = ["MoralisAPI", "HeliusAPI", "DexScreenerAPI"]

--- a/src/api/dexscreener.py
+++ b/src/api/dexscreener.py
@@ -1,0 +1,28 @@
+import aiohttp
+from typing import Any, Dict, List
+
+class DexScreenerAPI:
+    """Minimal async client for DEX Screener public endpoints."""
+
+    BASE_URL = "https://api.dexscreener.com/latest"
+
+    def __init__(self, session: aiohttp.ClientSession | None = None) -> None:
+        self.session = session
+
+    async def search_tokens(self, query: str) -> List[Dict[str, Any]]:
+        """Search for pairs by query and return raw pair data."""
+        url = f"{self.BASE_URL}/dex/search"
+        params = {"q": query}
+        close_session = False
+        if not self.session:
+            self.session = aiohttp.ClientSession()
+            close_session = True
+        try:
+            async with self.session.get(url, params=params, timeout=10) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                return data.get("pairs", []) if isinstance(data, dict) else []
+        finally:
+            if close_session:
+                await self.session.close()
+                self.session = None

--- a/test_bot.py
+++ b/test_bot.py
@@ -3,11 +3,14 @@
 import asyncio
 import os
 import sys
+import pytest
 from datetime import datetime
 from pathlib import Path
 
 # Adaugă directorul rădăcină la Python path
 sys.path.insert(0, str(Path(__file__).parent))
+
+pytestmark = pytest.mark.asyncio
 
 from src.bot import FeedAggregator, TradingEngine, setup_logging
 from src.bot.config import settings

--- a/test_dexscreener_api.py
+++ b/test_dexscreener_api.py
@@ -1,0 +1,15 @@
+import asyncio
+import pytest
+
+from src.api.dexscreener import DexScreenerAPI
+
+@pytest.mark.asyncio
+async def test_search_tokens_returns_list():
+    api = DexScreenerAPI()
+    try:
+        pairs = await api.search_tokens("solana")
+    except Exception:
+        pytest.skip("network unavailable")
+    assert isinstance(pairs, list)
+
+


### PR DESCRIPTION
## Summary
- add DexScreener API wrapper
- score tokens for 3x/5x/10x pump potential
- display opportunity in the dashboard
- document API usage in README
- fix tests and add DexScreener test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f97dba458832088d52f1a45f338ee